### PR TITLE
fix: Change another test model decimal PK to float

### DIFF
--- a/tests/model_formsets/models.py
+++ b/tests/model_formsets/models.py
@@ -134,7 +134,9 @@ class Product(models.Model):
 
 
 class Price(models.Model):
-    price = models.DecimalField(max_digits=10, decimal_places=2)
+    # Numeric field/Decimal Field is not supported by Spanner in unique key.
+    # So changed it to Float field.
+    price = models.FloatField()
     quantity = models.PositiveIntegerField()
 
     class Meta:


### PR DESCRIPTION
fix: decimal field in not supported in spanner for uniq key, changed that to float field in test models in model_formsets module